### PR TITLE
feat: add matrix-testing to circle-ci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,62 +1,88 @@
 version: 2.1
-orbs:
-  node: circleci/node@2.1.1
 
-defaults: &defaults
-  resource_class: small
-  docker:
-    - image: node:12
+executors:
+  docker-node:
+    parameters:
+      version:
+        default: "lts"
+        type: string
+    docker:
+      - image: cimg/node:<<parameters.version>>
 
 commands:
-  setup_snyk_user:
+  install:
     steps:
       - run:
-          name: Use snyk-main npmjs user
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-
-jobs:
+          name: Install
+          command: npm install
   test:
-    <<: *defaults
     steps:
-      - checkout
-      - setup_snyk_user
-      - node/install-packages:
-          override-ci: true
-          cache-key: package.json
+      - run:
+          name: Test
+          command: npm test
+  release:
+    steps:
+      - run:
+          name: Release
+          command: npx semantic-release
+  lint:
+    steps:
       - run:
           name: Lint
           command: npm run lint
-      - run:
-          name: Install JUnit coverage reporter
-          command: npm install --no-save jest-junit
-      - run:
-          name: Run tests with JUnit as reporter
-          command: npx jest --coverage --ci --maxWorkers=3 --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/junit/
-      - store_test_results:
-          path: ./reports/junit/
-      - store_artifacts:
-          path: ./reports/junit
-  release:
-    <<: *defaults
+
+jobs:
+  test:
+    resource_class: small
+    parameters:
+      version:
+        default: "lts"
+        type: string
+    executor:
+      name: docker-node
+      version: <<parameters.version>>
     steps:
       - checkout
-      - setup_snyk_user
-      - node/install-packages:
-          override-ci: true
-          cache-key: package.json
-      - run:
-          name: Release on GitHub
-          command: npx semantic-release@16
+      - install
+      - test
+
+  release:
+    resource_class: small
+    executor:
+      name: docker-node
+    steps:
+      - checkout
+      - install
+      - release
+
+  lint:
+    resource_class: small
+    executor:
+      name: docker-node
+    steps:
+      - checkout
+      - install
+      - lint
 
 workflows:
-  version: 2
+
   test:
     jobs:
+      - lint:
+          filters:
+            branches:
+              ignore:
+                - master
       - test:
-          name: Test
-          context: nodejs-install
+          requires:
+            - lint
+          matrix:
+            parameters:
+              version:
+                - 8.17.0
+                - 10.22.1
+                - 12.18.4
+                - 14.13.0
           filters:
             branches:
               ignore:
@@ -64,7 +90,6 @@ workflows:
   release:
     jobs:
       - release:
-          name: Release
           context: nodejs-lib-release
           filters:
             branches:

--- a/lib/lock-file-parser.ts
+++ b/lib/lock-file-parser.ts
@@ -3,12 +3,10 @@ import * as toml from 'toml';
 export function packageSpecsFrom(
   lockFileContents: string,
 ): PoetryLockFileDependency[] {
-
   const lockFile: PoetryLockFile = toml.parse(lockFileContents);
   if (!lockFile.package) {
     throw new LockFileNotValid();
   }
-
 
   return lockFile.package.map((pkg) => {
     return {
@@ -29,7 +27,7 @@ interface Package {
   dependencies?: Record<string, PoetryLockFileDependency>;
 }
 
-interface PoetryLockFileDependency {
+export interface PoetryLockFileDependency {
   name: string;
   version: string;
   dependencies: string[];
@@ -37,7 +35,7 @@ interface PoetryLockFileDependency {
 
 export class LockFileNotValid extends Error {
   constructor() {
-    super("The poetry.lock file contains no package stanza'")
+    super("The poetry.lock file contains no package stanza'");
     this.name = 'LockFileNotValid';
   }
 }

--- a/lib/manifest-parser.ts
+++ b/lib/manifest-parser.ts
@@ -4,15 +4,15 @@ export function getDependencyNamesFrom(
   manifestFileContents: string,
   includeDevDependencies: boolean,
 ): string[] {
-
   const manifest: PoetryManifestType = toml.parse(manifestFileContents);
   if (!manifest.tool?.poetry) {
-    throw new ManifestFileNotValid()
+    throw new ManifestFileNotValid();
   }
 
   const dependencies = dependenciesFrom(manifest);
-  const devDependencies: string[] = includeDevDependencies ?
-    devDependenciesFrom(manifest) : [];
+  const devDependencies: string[] = includeDevDependencies
+    ? devDependenciesFrom(manifest)
+    : [];
 
   return [...dependencies, ...devDependencies].filter(
     (pkgName) => pkgName != 'python',
@@ -29,8 +29,8 @@ function dependenciesFrom(manifest: PoetryManifestType) {
 
 export class ManifestFileNotValid extends Error {
   constructor() {
-    super('pyproject.toml is not a valid poetry file.')
-    this.name = "ManifestFileNotValid"
+    super('pyproject.toml is not a valid poetry file.');
+    this.name = 'ManifestFileNotValid';
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "@typescript-eslint/parser": "^2.34.0",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
-    "jest": "^26.0.1",
+    "jest": "^25.5.4",
     "prettier": "^2.0.5",
-    "ts-jest": "^26.0.0",
+    "ts-jest": "^25.5.1",
     "ts-node": "^8.10.1",
     "tsc-watch": "^4.2.7",
     "typescript": "^3.9.3"

--- a/test/unit/lib/index.test.ts
+++ b/test/unit/lib/index.test.ts
@@ -1,4 +1,4 @@
-import {buildDepGraph} from '../../../lib';
+import { buildDepGraph } from '../../../lib';
 
 describe('buildDepGraph', () => {
   describe('fileContents', () => {
@@ -53,5 +53,3 @@ describe('buildDepGraph', () => {
     );
   });
 });
-
-;

--- a/test/unit/lib/lock-file-parser.test.ts
+++ b/test/unit/lib/lock-file-parser.test.ts
@@ -1,9 +1,12 @@
-import { packageSpecsFrom, LockFileNotValid } from '../../../lib/lock-file-parser';
+import {
+  packageSpecsFrom,
+  LockFileNotValid,
+} from '../../../lib/lock-file-parser';
 
 describe('when loading lockfile', () => {
   it('should throw exception if package stanza not found', () => {
-    expect(() => packageSpecsFrom('')).toThrow(LockFileNotValid)
-  })
+    expect(() => packageSpecsFrom('')).toThrow(LockFileNotValid);
+  });
 
   it('should parse a lockfile and return a list of its packages and their dependency names', () => {
     const fileContents = `[[package]]
@@ -38,4 +41,4 @@ describe('when loading lockfile', () => {
     const lockFileDependencies = packageSpecsFrom('package = []');
     expect(lockFileDependencies.length).toBe(0);
   });
-})
+});

--- a/test/unit/lib/manifest-parser.test.ts
+++ b/test/unit/lib/manifest-parser.test.ts
@@ -1,13 +1,17 @@
-import { getDependencyNamesFrom, ManifestFileNotValid } from '../../../lib/manifest-parser';
+import {
+  getDependencyNamesFrom,
+  ManifestFileNotValid,
+} from '../../../lib/manifest-parser';
 
 describe('when loading manifest files', () => {
   it('should throw exception if tools.poetry stanza not found', () => {
-    expect(() => getDependencyNamesFrom('', false)).toThrow(ManifestFileNotValid)
-  })
+    expect(() => getDependencyNamesFrom('', false)).toThrow(
+      ManifestFileNotValid,
+    );
+  });
 
   it('should return list of dependency package names', () => {
-    const fileContents =
-      `[tool.poetry.dependencies]
+    const fileContents = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
       pkg_b = "^1.0"`;
     const poetryDependencies = getDependencyNamesFrom(fileContents, false);
@@ -17,8 +21,7 @@ describe('when loading manifest files', () => {
   });
 
   it('should not return python if listed as a dependency', () => {
-    const fileContents =
-      `[tool.poetry.dependencies]
+    const fileContents = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
       python = "~2.7 || ^3.5"`;
     const poetryDependencies = getDependencyNamesFrom(fileContents, false);
@@ -28,8 +31,7 @@ describe('when loading manifest files', () => {
   });
 
   it('should include devDependencies when asked to', () => {
-    const fileContents =
-      `[tool.poetry.dependencies]
+    const fileContents = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
       [tool.poetry.dev-dependencies]
       pkg_b = "^1.0"`;
@@ -54,4 +56,4 @@ describe('when loading manifest files', () => {
     const poetryDependencies = getDependencyNamesFrom('[tool.poetry]', false);
     expect(poetryDependencies.length).toBe(0);
   });
-})
+});


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

Added a lint step to run before test.
No longer relying on 'circleci node orb' because it depends on a
package-lock.json being present and newer versions do not appear to
allow overwriting this behaviour.

Fixed an invalid import from dist/ folder that was a leftover from a
previous refactoring gone wrong.

Downgraded jest versions to support testing on node8 .