### PR TITLE
feat: include project package info as root node on dep-graph generated.

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,10 +12,11 @@ export function buildDepGraph(
     manifestFileContents,
     includeDevDependencies,
   );
+  const packageDetails = manifest.pkgInfoFrom(manifestFileContents);
 
   const pkgSpecs = lockFile.packageSpecsFrom(lockFileContents);
 
-  const builder = new DepGraphBuilder({ name: 'poetry' });
+  const builder = new DepGraphBuilder({ name: 'poetry' }, packageDetails);
   addDependenciesToGraph(
     dependencyNames,
     pkgSpecs,

--- a/lib/manifest-parser.ts
+++ b/lib/manifest-parser.ts
@@ -1,5 +1,16 @@
 import * as toml from 'toml';
 
+export function pkgInfoFrom(manifestFileContents: string) {
+  const manifest: PoetryManifestType = toml.parse(manifestFileContents);
+  if (!manifest.tool?.poetry) {
+    throw new ManifestFileNotValid();
+  }
+  return {
+    name: manifest.tool.poetry.name,
+    version: manifest.tool.poetry.version,
+  };
+}
+
 export function getDependencyNamesFrom(
   manifestFileContents: string,
   includeDevDependencies: boolean,
@@ -34,6 +45,12 @@ export class ManifestFileNotValid extends Error {
   }
 }
 
+export interface PoetryManifest {
+  name: string;
+  version: string;
+  dependencies: string[];
+}
+
 interface PoetryManifestType {
   tool: Tool;
 }
@@ -43,6 +60,8 @@ interface Tool {
 }
 
 interface Poetry {
+  name: string;
+  version: string;
   dependencies: Record<string, string>;
   'dev-dependencies': Record<string, string>;
 }

--- a/test/fixtures/index.test.ts
+++ b/test/fixtures/index.test.ts
@@ -6,10 +6,24 @@ describe('buildDepGraph', () => {
   let depGraphBuilder: DepGraphBuilder;
 
   beforeEach(() => {
-    depGraphBuilder = new DepGraphBuilder({ name: 'poetry' });
+    depGraphBuilder = new DepGraphBuilder(
+      { name: 'poetry' },
+      { name: 'myPkg', version: '1.42.2' },
+    );
   });
 
-  it('oneDepNoTransitives yields a graph with only package and its dep', () => {
+  it('should build a dep-graph with root node named and versioned as per project info in manifest file.', () => {
+    const expectedGraph = depGraphBuilder.build();
+    const manifestContents = `[tool.poetry]
+      name = "myPkg"
+      version = "1.42.2"`;
+    const lockfileContents = `package = []`;
+
+    let result = buildDepGraph(manifestContents, lockfileContents);
+    expect(result.equals(expectedGraph)).toBeTruthy();
+  });
+
+  it('on fixture oneDepNoTransitives yields a graph with only package and its dep', () => {
     const expectedGraph = depGraphBuilder
       .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')
       .connectDep(depGraphBuilder.rootNodeId, 'six')
@@ -22,7 +36,7 @@ describe('buildDepGraph', () => {
     ).toBe(true);
   });
 
-  it('oneDepWithTransitive yields graph with the two packages', () => {
+  it('on fixture oneDepWithTransitive yields graph with the two packages', () => {
     const expectedGraph = depGraphBuilder
       .addPkgNode({ name: 'jinja2', version: '2.11.2' }, 'jinja2')
       .connectDep(depGraphBuilder.rootNodeId, 'jinja2')
@@ -37,7 +51,7 @@ describe('buildDepGraph', () => {
     ).toBe(true);
   });
 
-  describe('oneDepWithOneDevDep yields graph with two packages', () => {
+  describe('on fixture oneDepWithOneDevDep yields graph with two packages', () => {
     const scenarioPath = 'scenarios/one-dep-one-devdep';
 
     it('oneDepWithOneDevDep yields graph with two packages when including dev packages', () => {
@@ -56,7 +70,7 @@ describe('buildDepGraph', () => {
       expect(isEqual).toBe(true);
     });
 
-    it('oneDepWithOneDevDep yields graph with one package when ignoring dev packages', () => {
+    it('on fixture oneDepWithOneDevDep yields graph with one package when ignoring dev packages', () => {
       const includeDevDependencies = false;
       const expectedGraph = depGraphBuilder
         .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')

--- a/test/fixtures/scenarios/one-dep-no-transitives/pyproject.toml
+++ b/test/fixtures/scenarios/one-dep-no-transitives/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "poetry-fixtures-project"
-version = "0.1.0"
+name = "myPkg"
+version = "1.42.2"
 description = ""
 authors = []
 

--- a/test/fixtures/scenarios/one-dep-one-devdep/pyproject.toml
+++ b/test/fixtures/scenarios/one-dep-one-devdep/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "poetry-fixtures-project"
-version = "0.1.0"
+name = "myPkg"
+version = "1.42.2"
 description = ""
 authors = []
 

--- a/test/fixtures/scenarios/one-dep-with-transitive/pyproject.toml
+++ b/test/fixtures/scenarios/one-dep-with-transitive/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "poetry-fixtures-project"
-version = "0.1.0"
+name = "myPkg"
+version = "1.42.2"
 description = ""
 authors = []
 

--- a/test/unit/lib/manifest-parser.test.ts
+++ b/test/unit/lib/manifest-parser.test.ts
@@ -1,9 +1,20 @@
 import {
   getDependencyNamesFrom,
   ManifestFileNotValid,
+  pkgInfoFrom,
 } from '../../../lib/manifest-parser';
 
 describe('when loading manifest files', () => {
+  it('should return package info given the contents of a manifest', () => {
+    const fileContents = `[tool.poetry]
+        name = "poetry-fixtures-project"
+        version = "0.1.0"`;
+
+    const { name, version } = pkgInfoFrom(fileContents);
+    expect(name).toBe('poetry-fixtures-project');
+    expect(version).toBe('0.1.0');
+  });
+
   it('should throw exception if tools.poetry stanza not found', () => {
     expect(() => getDependencyNamesFrom('', false)).toThrow(
       ManifestFileNotValid,


### PR DESCRIPTION
### What this does

Includes project package info as root node on dep-graph generated as previously this was an omission. 