### PR TITLE
fix: no longer fail on missing lockfile metadata

### DIFF
--- a/lib/poetry-dep-graph-builder.ts
+++ b/lib/poetry-dep-graph-builder.ts
@@ -50,7 +50,7 @@ function addDependenciesForPkg(
   pkgName = pkgName.replace(/_/g, '-');
 
   const pkg = pkgLockInfoFor(pkgName, pkgSpecs);
-  if (isPkgAlreadyInGraph(pkg, builder)) {
+  if (!pkg || isPkgAlreadyInGraph(pkg, builder)) {
     return;
   }
 
@@ -74,20 +74,15 @@ function isPkgAlreadyInGraph(
 function pkgLockInfoFor(
   pkgName: string,
   pkgSpecs: PoetryLockFileDependency[],
-): PoetryLockFileDependency {
+): PoetryLockFileDependency | undefined {
   const pkgLockInfo = pkgSpecs.find(
     (lockItem) => lockItem.name.toLowerCase() === pkgName.toLowerCase(),
   );
 
   if (!pkgLockInfo) {
-    throw new DependencyNotFound(pkgName);
+    console.warn(
+      `Could not find any lockfile metadata for package: ${pkgName}. This package will not be represented in the dependency graph.`,
+    );
   }
   return pkgLockInfo;
-}
-
-export class DependencyNotFound extends Error {
-  constructor(pkgName: string) {
-    super(`Unable to find dependencies in poetry.lock for package: ${pkgName}`);
-    this.name = DependencyNotFound.name;
-  }
 }

--- a/test/fixtures/index.test.ts
+++ b/test/fixtures/index.test.ts
@@ -111,6 +111,14 @@ describe('buildDepGraph', () => {
     expect(actualGraph).toBeDefined();
     expect(actualGraph.getDepPkgs().length).toBe(1);
   });
+
+  it('on fixture with conflicting python declarations yields graph successfully', () => {
+    jest.spyOn(console, 'warn');
+    const actualGraph = depGraphForScenarioAt(
+      'scenarios/conflicting-python-declarations',
+    );
+    expect(actualGraph).toBeDefined();
+  });
 });
 
 function depGraphForScenarioAt(

--- a/test/fixtures/scenarios/conflicting-python-declarations/poetry.lock
+++ b/test/fixtures/scenarios/conflicting-python-declarations/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+content-hash = "3e502a6d9becf1fe8f342d165eb704eb356262a088c59239ff5e0d183bef04b5"
+lock-version = "1.0"
+python-versions = "^3.8"
+
+[metadata.files]

--- a/test/fixtures/scenarios/conflicting-python-declarations/pyproject.toml
+++ b/test/fixtures/scenarios/conflicting-python-declarations/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "conflicting-python-declarations"
+version = "0.1.0"
+description = ""
+authors = ["Daniel Trunley <daniel.trunley@snyk.io>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+typing = { version = "*", python = "<3.4" }
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/test/unit/lib/poetry-dep-graph-builder.test.ts
+++ b/test/unit/lib/poetry-dep-graph-builder.test.ts
@@ -1,7 +1,4 @@
-import {
-  build,
-  DependencyNotFound,
-} from '../../../lib/poetry-dep-graph-builder';
+import { build } from '../../../lib/poetry-dep-graph-builder';
 import { PoetryLockFileDependency } from '../../../lib/lock-file-parser';
 import { PkgInfo } from '@snyk/dep-graph';
 
@@ -79,19 +76,20 @@ describe('poetry-dep-graph-builder', () => {
       expect(bNodes).toHaveLength(1);
     });
 
-    it('should throw DependencyNotFound if metadata cannot be found in pkgSpecs', () => {
+    it('should log warning if metadata cannot be found in pkgSpecs', () => {
       // given
+      const missingPkg = 'non-existent-pkg';
       const pkgA = generatePoetryLockFileDependency('pkg-a', [
         'non-existent-pkg',
       ]);
+      const consoleSpy = jest.spyOn(console, 'warn');
 
       // when
-      const errorResult = () => {
-        build(rootPkg, [pkgA.name], [pkgA]);
-      };
+      build(rootPkg, [pkgA.name], [pkgA]);
 
       // then
-      expect(errorResult).toThrow(DependencyNotFound);
+      const expectedWarningMessage = `Could not find any lockfile metadata for package: ${missingPkg}. This package will not be represented in the dependency graph.`;
+      expect(consoleSpy).toBeCalledWith(expectedWarningMessage);
     });
   });
 });


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

In the manifest file for Poetry, the customer can specify a version for Python. Equally, when specifying a dependency, they can set a version range. Sometimes these can conflict and when they do, the dependency is not added to the lockfile. 
Rather than recreate the behaviour, we thought it would be best for the parser to not error if lockfile metadata cannot be located, but warn that we won't be able to build dependencies from this node. This is with future uncovered scenarios in mind.

### More information

- [LOKI-175](https://snyksec.atlassian.net/browse/LOKI-175)