### PR TITLE
fix: consider hyphens and underscores equivalent in package search

### DIFF
--- a/lib/poetry-dep-graph-builder.ts
+++ b/lib/poetry-dep-graph-builder.ts
@@ -52,9 +52,9 @@ function addDependenciesForPkg(
     return;
   }
 
-  const pkgInfo: PkgInfo = { name: pkgName, version: pkg.version };
-  builder.addPkgNode(pkgInfo, pkgName).connectDep(parentNodeId, pkgName);
-  addDependenciesToGraph(pkg.dependencies, pkgSpecs, pkgName, builder);
+  const pkgInfo: PkgInfo = { name: pkg.name, version: pkg.version };
+  builder.addPkgNode(pkgInfo, pkg.name).connectDep(parentNodeId, pkg.name);
+  addDependenciesToGraph(pkg.dependencies, pkgSpecs, pkg.name, builder);
 }
 
 function isPkgAlreadyInGraph(
@@ -73,8 +73,15 @@ function pkgLockInfoFor(
   pkgName: string,
   pkgSpecs: PoetryLockFileDependency[],
 ): PoetryLockFileDependency | undefined {
+  // From PEP 426 https://www.python.org/dev/peps/pep-0426/#name
+  // All comparisons of distribution names MUST be case insensitive, and MUST
+  // consider hyphens and underscores to be equivalent
   const pkgLockInfo = pkgSpecs.find(
-    (lockItem) => lockItem.name.toLowerCase() === pkgName.toLowerCase(),
+    (lockItem) =>
+      lockItem.name.toLowerCase().replace(/_/g, '-') ===
+        pkgName.toLowerCase().replace(/_/g, '-') ||
+      lockItem.name.toLowerCase().replace(/-/g, '_') ===
+        pkgName.toLowerCase().replace(/-/g, '_'),
   );
 
   if (!pkgLockInfo) {

--- a/test/fixtures/index.test.ts
+++ b/test/fixtures/index.test.ts
@@ -40,8 +40,8 @@ describe('buildDepGraph', () => {
     const expectedGraph = depGraphBuilder
       .addPkgNode({ name: 'jinja2', version: '2.11.2' }, 'jinja2')
       .connectDep(depGraphBuilder.rootNodeId, 'jinja2')
-      .addPkgNode({ name: 'MarkupSafe', version: '1.1.1' }, 'MarkupSafe')
-      .connectDep('jinja2', 'MarkupSafe')
+      .addPkgNode({ name: 'markupsafe', version: '1.1.1' }, 'markupsafe')
+      .connectDep('jinja2', 'markupsafe')
       .build();
 
     expect(
@@ -59,8 +59,8 @@ describe('buildDepGraph', () => {
       const expectedGraph = depGraphBuilder
         .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')
         .connectDep(depGraphBuilder.rootNodeId, 'six')
-        .addPkgNode({ name: 'isOdd', version: '0.1.2' }, 'isOdd')
-        .connectDep(depGraphBuilder.rootNodeId, 'isOdd')
+        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd')
+        .connectDep(depGraphBuilder.rootNodeId, 'isodd')
         .build();
 
       const isEqual = depGraphForScenarioAt(
@@ -99,7 +99,8 @@ describe('buildDepGraph', () => {
   });
 
   it('on fixture with conflicting python declarations yields graph successfully', () => {
-    jest.spyOn(console, 'warn');
+    // Spy only exists here to prevent polluting the logs with a warning log we expect to see
+    jest.spyOn(console, 'warn').mockImplementation();
     const actualGraph = depGraphForScenarioAt(
       'scenarios/conflicting-python-declarations',
     );


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

Alters the lookup between the manifest and lock file to follow [PEP 426](https://www.python.org/dev/peps/pep-0426/#name), specifically the following part: 

> All comparisons of distribution names MUST be case insensitive, and MUST consider hyphens and underscores to be equivalent.

Poetry will allow any case or combination of hyphens and underscores in the manifest file. However, the value in the lockfile is the source of truth. 