### PR TITLE
fix: connect repeated deps

### DIFF
--- a/lib/poetry-dep-graph-builder.ts
+++ b/lib/poetry-dep-graph-builder.ts
@@ -48,7 +48,11 @@ function addDependenciesForPkg(
   }
 
   const pkg = pkgLockInfoFor(pkgName, pkgSpecs);
-  if (!pkg || isPkgAlreadyInGraph(pkg, builder)) {
+  if (!pkg) {
+    return;
+  }
+  if (isPkgAlreadyInGraph(pkg, builder)) {
+    builder.connectDep(parentNodeId, pkg.name);
     return;
   }
 

--- a/test/unit/lib/poetry-dep-graph-builder.test.ts
+++ b/test/unit/lib/poetry-dep-graph-builder.test.ts
@@ -60,9 +60,14 @@ describe('poetry-dep-graph-builder', () => {
       // given
       const pkgA = generatePoetryLockFileDependency('pkg-a', ['pkg-b']);
       const pkgB = generatePoetryLockFileDependency('pkg-b', ['pkg-a']);
+      const pkgC = generatePoetryLockFileDependency('pkg-c', ['pkg-a']);
 
       // when
-      const result = build(rootPkg, [pkgA.name, pkgB.name], [pkgA, pkgB]);
+      const result = build(
+        rootPkg,
+        [pkgA.name, pkgB.name, pkgC.name],
+        [pkgA, pkgB, pkgC],
+      );
 
       // then
       expect(result).toBeDefined();
@@ -72,8 +77,13 @@ describe('poetry-dep-graph-builder', () => {
       const bNodes = result
         .toJSON()
         .graph.nodes.filter((node) => node.nodeId === pkgB.name);
+      const cNode = result
+        .toJSON()
+        .graph.nodes.find((node) => node.nodeId === pkgC.name);
       expect(aNodes).toHaveLength(1);
       expect(bNodes).toHaveLength(1);
+      expect(cNode).toBeDefined();
+      expect(cNode!.deps).toHaveLength(1);
     });
 
     it('should treat underscores in manifest as equal to hyphens in lockfile', () => {


### PR DESCRIPTION
- [x] Tests written and linted
- [x] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [x] Reviewed by Snyk team

### What this does

When iterating over the deps in the pyproject.toml and poetry.lock: for new deps we add the node and then connect the dep. For existing dep nodes we should still connect the dep.

