### PR TITLE
fix: support quoted keys in inline tables

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,8 +14,7 @@ export function buildDepGraph(
     includeDevDependencies,
   );
   const pkgDetails: PkgInfo = manifest.pkgInfoFrom(manifestFileContents);
-  const pkgSpecs: PoetryLockFileDependency[] = lockFile.packageSpecsFrom(
-    lockFileContents,
-  );
+  const pkgSpecs: PoetryLockFileDependency[] =
+    lockFile.packageSpecsFrom(lockFileContents);
   return poetryDepGraphBuilder.build(pkgDetails, dependencyNames, pkgSpecs);
 }

--- a/lib/lock-file-parser.ts
+++ b/lib/lock-file-parser.ts
@@ -1,9 +1,10 @@
-import * as toml from 'toml';
+import * as toml from '@iarna/toml';
 
 export function packageSpecsFrom(
   lockFileContents: string,
 ): PoetryLockFileDependency[] {
-  const lockFile: PoetryLockFile = toml.parse(lockFileContents);
+  const lockFile = toml.parse(lockFileContents) as unknown as PoetryLockFile;
+
   if (!lockFile.package) {
     throw new LockFileNotValid();
   }

--- a/lib/manifest-parser.ts
+++ b/lib/manifest-parser.ts
@@ -1,9 +1,11 @@
-import * as toml from 'toml';
+import * as toml from '@iarna/toml';
 
 export function pkgInfoFrom(manifestFileContents: string) {
   let manifest: PoetryManifestType;
   try {
-    manifest = toml.parse(manifestFileContents);
+    manifest = toml.parse(
+      manifestFileContents,
+    ) as unknown as PoetryManifestType;
     return {
       name: manifest.tool.poetry.name,
       version: manifest.tool.poetry.version,
@@ -17,7 +19,9 @@ export function getDependencyNamesFrom(
   manifestFileContents: string,
   includeDevDependencies: boolean,
 ): string[] {
-  const manifest: PoetryManifestType = toml.parse(manifestFileContents);
+  const manifest = toml.parse(
+    manifestFileContents,
+  ) as unknown as PoetryManifestType;
   if (!manifest.tool?.poetry) {
     throw new ManifestFileNotValid();
   }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "prepare": "npm run build"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@snyk/cli-interface": "^2.9.2",
     "@snyk/dep-graph": "^1.23.0",
     "debug": "^4.2.0",
-    "toml": "^3.0.0",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/test/unit/lib/manifest-parser.test.ts
+++ b/test/unit/lib/manifest-parser.test.ts
@@ -80,5 +80,13 @@ describe('when loading manifest files', () => {
       const poetryDependencies = getDependencyNamesFrom('[tool.poetry]', false);
       expect(poetryDependencies.length).toBe(0);
     });
+
+    it('should handle quoted keys in inline tables', () => {
+      const fileContents = `[tool.poetry.dependencies]
+      pkg_a = {"version" = "^1.0"}`;
+      const poetryDependencies = getDependencyNamesFrom(fileContents, false);
+      expect(poetryDependencies.length).toBe(1);
+      expect(poetryDependencies.includes('pkg_a')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does
Add support for quoted keys in inline tables (and probably more toml features)  

_Explain why this PR exists_
current toml library doesn't support quoted keys in inline tables

today we're using `toml` package, which was published 3 years ago and doesnt follow current TOML spec
@iarna/toml was published 1 year ago and has better support for updated spec (v0.5)

### More information

- Relevant issue: https://github.com/snyk/snyk-poetry-lockfile-parser/issues/14