### PR TITLE
feat: add dev or prod scope to dep graph label for node

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,12 +9,12 @@ export function buildDepGraph(
   lockFileContents: string,
   includeDevDependencies = false,
 ): DepGraph {
-  const dependencyNames: string[] = manifest.getDependencyNamesFrom(
+  const dependencies: manifest.Dependency[] = manifest.getDependenciesFrom(
     manifestFileContents,
     includeDevDependencies,
   );
   const pkgDetails: PkgInfo = manifest.pkgInfoFrom(manifestFileContents);
   const pkgSpecs: PoetryLockFileDependency[] =
     lockFile.packageSpecsFrom(lockFileContents);
-  return poetryDepGraphBuilder.build(pkgDetails, dependencyNames, pkgSpecs);
+  return poetryDepGraphBuilder.build(pkgDetails, dependencies, pkgSpecs);
 }

--- a/lib/manifest-parser.ts
+++ b/lib/manifest-parser.ts
@@ -1,6 +1,7 @@
 import * as toml from '@iarna/toml';
+import { PkgInfo } from '@snyk/dep-graph';
 
-export function pkgInfoFrom(manifestFileContents: string) {
+export function pkgInfoFrom(manifestFileContents: string): PkgInfo {
   let manifest: PoetryManifestType;
   try {
     manifest = toml.parse(
@@ -15,10 +16,10 @@ export function pkgInfoFrom(manifestFileContents: string) {
   }
 }
 
-export function getDependencyNamesFrom(
+export function getDependenciesFrom(
   manifestFileContents: string,
   includeDevDependencies: boolean,
-): string[] {
+): Dependency[] {
   const manifest = toml.parse(
     manifestFileContents,
   ) as unknown as PoetryManifestType;
@@ -26,13 +27,19 @@ export function getDependencyNamesFrom(
     throw new ManifestFileNotValid();
   }
 
-  const dependencies = dependenciesFrom(manifest);
-  const devDependencies: string[] = includeDevDependencies
-    ? devDependenciesFrom(manifest)
-    : [];
+  const dependencies: Dependency[] = dependenciesFrom(manifest).map((dep) => ({
+    name: dep,
+    isDev: false,
+  }));
+  const devDependencies: Dependency[] = (
+    includeDevDependencies ? devDependenciesFrom(manifest) : []
+  ).map((devDep) => ({
+    name: devDep,
+    isDev: true,
+  }));
 
   return [...dependencies, ...devDependencies].filter(
-    (pkgName) => pkgName != 'python',
+    (pkg) => pkg.name != 'python',
   );
 }
 
@@ -95,4 +102,9 @@ interface Poetry {
   dependencies: Dependencies;
   'dev-dependencies': Dependencies;
   group: Group;
+}
+
+export interface Dependency {
+  name: string;
+  isDev: boolean;
 }

--- a/test/fixtures/index.test.ts
+++ b/test/fixtures/index.test.ts
@@ -25,7 +25,9 @@ describe('buildDepGraph', () => {
 
   it('on fixture oneDepNoTransitives yields a graph with only package and its dep', () => {
     const expectedGraph = depGraphBuilder
-      .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')
+      .addPkgNode({ name: 'six', version: '1.15.0' }, 'six', {
+        labels: { scope: 'prod' },
+      })
       .connectDep(depGraphBuilder.rootNodeId, 'six')
       .build();
 
@@ -38,9 +40,13 @@ describe('buildDepGraph', () => {
 
   it('on fixture oneDepWithTransitive yields graph with the two packages', () => {
     const expectedGraph = depGraphBuilder
-      .addPkgNode({ name: 'jinja2', version: '2.11.2' }, 'jinja2')
+      .addPkgNode({ name: 'jinja2', version: '2.11.2' }, 'jinja2', {
+        labels: { scope: 'prod' },
+      })
       .connectDep(depGraphBuilder.rootNodeId, 'jinja2')
-      .addPkgNode({ name: 'markupsafe', version: '1.1.1' }, 'markupsafe')
+      .addPkgNode({ name: 'markupsafe', version: '1.1.1' }, 'markupsafe', {
+        labels: { scope: 'prod' },
+      })
       .connectDep('jinja2', 'markupsafe')
       .build();
 
@@ -57,9 +63,13 @@ describe('buildDepGraph', () => {
     it('oneDepWithOneDevDep yields graph with two packages when including dev packages', () => {
       const includeDevDependencies = true;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.15.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
-        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd')
+        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'isodd')
         .build();
 
@@ -73,7 +83,9 @@ describe('buildDepGraph', () => {
     it('on fixture oneDepWithOneDevDep yields graph with one package when ignoring dev packages', () => {
       const includeDevDependencies = false;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.15.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.15.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
         .build();
 
@@ -91,9 +103,13 @@ describe('buildDepGraph', () => {
     it('oneDevDepWithOneDevDepGroup yields graph with two packages when including dev packages', () => {
       const includeDevDependencies = true;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
-        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd')
+        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'isodd')
         .build();
 
@@ -107,7 +123,9 @@ describe('buildDepGraph', () => {
     it('on fixture oneDevDepWithOneDevDepGroup yields graph with one package when ignoring dev packages', () => {
       const includeDevDependencies = false;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
         .build();
 
@@ -125,11 +143,17 @@ describe('buildDepGraph', () => {
     it('oneDepWithOneDevDepAndOneDevDepGroup yields graph with three packages when including dev packages', () => {
       const includeDevDependencies = true;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
-        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd')
+        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'isodd')
-        .addPkgNode({ name: 'simple-enum', version: '0.0.6' }, 'simple-enum')
+        .addPkgNode({ name: 'simple-enum', version: '0.0.6' }, 'simple-enum', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'simple-enum')
         .build();
 
@@ -143,7 +167,9 @@ describe('buildDepGraph', () => {
     it('on fixture oneDepWithOneDevDepAndOneDevDepGroup yields graph with one package when ignoring dev packages', () => {
       const includeDevDependencies = false;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
         .build();
 
@@ -161,13 +187,21 @@ describe('buildDepGraph', () => {
     it('oneDepWithOneDevDepAndMultipleDevDepGroups yields graph with three packages when including dev packages', () => {
       const includeDevDependencies = true;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
-        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd')
+        .addPkgNode({ name: 'isodd', version: '0.1.2' }, 'isodd', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'isodd')
-        .addPkgNode({ name: 'simple-enum', version: '0.0.6' }, 'simple-enum')
+        .addPkgNode({ name: 'simple-enum', version: '0.0.6' }, 'simple-enum', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'simple-enum')
-        .addPkgNode({ name: 'whattype', version: '0.0.1' }, 'whattype')
+        .addPkgNode({ name: 'whattype', version: '0.0.1' }, 'whattype', {
+          labels: { scope: 'dev' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'whattype')
         .build();
 
@@ -181,7 +215,9 @@ describe('buildDepGraph', () => {
     it('on fixture oneDepWithOneDevDepAndMultipleDevDepGroups yields graph with one package when ignoring dev packages', () => {
       const includeDevDependencies = false;
       const expectedGraph = depGraphBuilder
-        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six')
+        .addPkgNode({ name: 'six', version: '1.16.0' }, 'six', {
+          labels: { scope: 'prod' },
+        })
         .connectDep(depGraphBuilder.rootNodeId, 'six')
         .build();
 

--- a/test/unit/lib/manifest-parser.test.ts
+++ b/test/unit/lib/manifest-parser.test.ts
@@ -1,5 +1,5 @@
 import {
-  getDependencyNamesFrom,
+  getDependenciesFrom,
   ManifestFileNotValid,
   pkgInfoFrom,
 } from '../../../lib/manifest-parser';
@@ -27,9 +27,9 @@ describe('when loading manifest files', () => {
     });
   });
 
-  describe('getDependencyNamesFrom', () => {
+  describe('getDependenciesFrom', () => {
     it('should throw exception if tools.poetry stanza not found', () => {
-      expect(() => getDependencyNamesFrom('', false)).toThrow(
+      expect(() => getDependenciesFrom('', false)).toThrow(
         ManifestFileNotValid,
       );
     });
@@ -38,20 +38,22 @@ describe('when loading manifest files', () => {
       const fileContents = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
       pkg_b = "^1.0"`;
-      const poetryDependencies = getDependencyNamesFrom(fileContents, false);
+      const poetryDependencies = getDependenciesFrom(fileContents, false);
       expect(poetryDependencies.length).toBe(2);
-      expect(poetryDependencies.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies.includes('pkg_b')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_a')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_b')).toBe(true);
     });
 
     it('should not return python if listed as a dependency', () => {
       const fileContents = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
       python = "~2.7 || ^3.5"`;
-      const poetryDependencies = getDependencyNamesFrom(fileContents, false);
+      const poetryDependencies = getDependenciesFrom(fileContents, false);
       expect(poetryDependencies.length).toBe(1);
-      expect(poetryDependencies.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies.includes('python')).toBe(false);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_a')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'python')).toBe(
+        false,
+      );
     });
 
     it('should include devDependencies when asked to', () => {
@@ -60,10 +62,10 @@ describe('when loading manifest files', () => {
       pkg_a = "^2.11"
       [tool.poetry.dev-dependencies]
       pkg_b = "^1.0"`;
-      const poetryDependencies = getDependencyNamesFrom(fileContents, true);
+      const poetryDependencies = getDependenciesFrom(fileContents, true);
       expect(poetryDependencies.length).toBe(2);
-      expect(poetryDependencies.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies.includes('pkg_b')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_a')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_b')).toBe(true);
 
       // tool.poetry.group.<group>
       const fileContents2 = `[tool.poetry.dependencies]
@@ -71,10 +73,14 @@ describe('when loading manifest files', () => {
       [tool.poetry.group.dev.dependencies]
       pkg_c = "^1.0"
       `;
-      const poetryDependencies2 = getDependencyNamesFrom(fileContents2, true);
+      const poetryDependencies2 = getDependenciesFrom(fileContents2, true);
       expect(poetryDependencies2.length).toBe(2);
-      expect(poetryDependencies2.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies2.includes('pkg_c')).toBe(true);
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_a')).toBe(
+        true,
+      );
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_c')).toBe(
+        true,
+      );
 
       // tool.poetry.dev-dependencies & tool.poetry.group.<group>
       const fileContents3 = `[tool.poetry.dependencies]
@@ -84,11 +90,17 @@ describe('when loading manifest files', () => {
       [tool.poetry.group.dev.dependencies]
       pkg_c = "^1.0"
       `;
-      const poetryDependencies3 = getDependencyNamesFrom(fileContents3, true);
+      const poetryDependencies3 = getDependenciesFrom(fileContents3, true);
       expect(poetryDependencies3.length).toBe(3);
-      expect(poetryDependencies3.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies3.includes('pkg_b')).toBe(true);
-      expect(poetryDependencies3.includes('pkg_c')).toBe(true);
+      expect(poetryDependencies3.some((dep) => dep.name === 'pkg_a')).toBe(
+        true,
+      );
+      expect(poetryDependencies3.some((dep) => dep.name === 'pkg_b')).toBe(
+        true,
+      );
+      expect(poetryDependencies3.some((dep) => dep.name === 'pkg_c')).toBe(
+        true,
+      );
 
       // tool.poetry.dev-dependencies & multiple tool.poetry.group.<group>
       const fileContents4 = `[tool.poetry.dependencies]
@@ -102,13 +114,23 @@ describe('when loading manifest files', () => {
       [tool.poetry.group.even-more-dev.dependencies]
       pkg_e = "^1.0"
       `;
-      const poetryDependencies4 = getDependencyNamesFrom(fileContents4, true);
+      const poetryDependencies4 = getDependenciesFrom(fileContents4, true);
       expect(poetryDependencies4.length).toBe(5);
-      expect(poetryDependencies4.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies4.includes('pkg_b')).toBe(true);
-      expect(poetryDependencies4.includes('pkg_c')).toBe(true);
-      expect(poetryDependencies4.includes('pkg_d')).toBe(true);
-      expect(poetryDependencies4.includes('pkg_e')).toBe(true);
+      expect(poetryDependencies4.some((dep) => dep.name === 'pkg_a')).toBe(
+        true,
+      );
+      expect(poetryDependencies4.some((dep) => dep.name === 'pkg_b')).toBe(
+        true,
+      );
+      expect(poetryDependencies4.some((dep) => dep.name === 'pkg_c')).toBe(
+        true,
+      );
+      expect(poetryDependencies4.some((dep) => dep.name === 'pkg_d')).toBe(
+        true,
+      );
+      expect(poetryDependencies4.some((dep) => dep.name === 'pkg_e')).toBe(
+        true,
+      );
     });
 
     it('should not include devDependencies when not asked to', () => {
@@ -116,10 +138,12 @@ describe('when loading manifest files', () => {
       pkg_a = "^2.11"
       [tool.poetry.dev-dependencies]
       pkg_b = "^1.0"`;
-      const poetryDependencies = getDependencyNamesFrom(fileContents, false);
+      const poetryDependencies = getDependenciesFrom(fileContents, false);
       expect(poetryDependencies.length).toBe(1);
-      expect(poetryDependencies.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies.includes('pkg_b')).toBe(false);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_a')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_b')).toBe(
+        false,
+      );
 
       const fileContents2 = `[tool.poetry.dependencies]
       pkg_a = "^2.11"
@@ -130,25 +154,33 @@ describe('when loading manifest files', () => {
       [tool.poetry.group.more-dev.dependencies]
       pkg_d = "^1.0"
       `;
-      const poetryDependencies2 = getDependencyNamesFrom(fileContents2, false);
+      const poetryDependencies2 = getDependenciesFrom(fileContents2, false);
       expect(poetryDependencies2.length).toBe(1);
-      expect(poetryDependencies2.includes('pkg_a')).toBe(true);
-      expect(poetryDependencies2.includes('pkg_b')).toBe(false);
-      expect(poetryDependencies2.includes('pkg_c')).toBe(false);
-      expect(poetryDependencies2.includes('pkg_d')).toBe(false);
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_a')).toBe(
+        true,
+      );
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_b')).toBe(
+        false,
+      );
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_c')).toBe(
+        false,
+      );
+      expect(poetryDependencies2.some((dep) => dep.name === 'pkg_d')).toBe(
+        false,
+      );
     });
 
     it('should not return any dependencies when dependency stanza not present', () => {
-      const poetryDependencies = getDependencyNamesFrom('[tool.poetry]', false);
+      const poetryDependencies = getDependenciesFrom('[tool.poetry]', false);
       expect(poetryDependencies.length).toBe(0);
     });
 
     it('should handle quoted keys in inline tables', () => {
       const fileContents = `[tool.poetry.dependencies]
       pkg_a = {"version" = "^1.0"}`;
-      const poetryDependencies = getDependencyNamesFrom(fileContents, false);
+      const poetryDependencies = getDependenciesFrom(fileContents, false);
       expect(poetryDependencies.length).toBe(1);
-      expect(poetryDependencies.includes('pkg_a')).toBe(true);
+      expect(poetryDependencies.some((dep) => dep.name === 'pkg_a')).toBe(true);
     });
   });
 });

--- a/test/unit/lib/poetry-dep-graph-builder.test.ts
+++ b/test/unit/lib/poetry-dep-graph-builder.test.ts
@@ -14,7 +14,14 @@ describe('poetry-dep-graph-builder', () => {
       const pkgSpecs: PoetryLockFileDependency[] = [pkgA, pkgB, pkgC];
 
       // when
-      const result = build(rootPkg, ['pkg-a', 'pkg_b'], pkgSpecs);
+      const result = build(
+        rootPkg,
+        [
+          { name: 'pkg-a', isDev: false },
+          { name: 'pkg-b', isDev: false },
+        ],
+        pkgSpecs,
+      );
 
       // then
       const resultGraph = result.toJSON().graph;
@@ -45,7 +52,7 @@ describe('poetry-dep-graph-builder', () => {
       ];
 
       // when
-      const result = build(rootPkg, [pkgA.name], [pkgA]);
+      const result = build(rootPkg, [{ name: 'pkg-a', isDev: false }], [pkgA]);
 
       // then
       const resultGraph = result.toJSON().graph;
@@ -65,7 +72,11 @@ describe('poetry-dep-graph-builder', () => {
       // when
       const result = build(
         rootPkg,
-        [pkgA.name, pkgB.name, pkgC.name],
+        [
+          { name: 'pkg-a', isDev: false },
+          { name: 'pkg-b', isDev: false },
+          { name: 'pkg-c', isDev: false },
+        ],
         [pkgA, pkgB, pkgC],
       );
 
@@ -91,7 +102,7 @@ describe('poetry-dep-graph-builder', () => {
       const pkgA = generatePoetryLockFileDependency('pkg-a');
 
       // when
-      const result = build(rootPkg, ['pkg_a'], [pkgA]);
+      const result = build(rootPkg, [{ name: 'pkg-a', isDev: false }], [pkgA]);
 
       // then
       expect(result).toBeDefined();
@@ -105,7 +116,7 @@ describe('poetry-dep-graph-builder', () => {
       const pkgA = generatePoetryLockFileDependency('pkg_a');
 
       // when
-      const result = build(rootPkg, ['pkg-a'], [pkgA]);
+      const result = build(rootPkg, [{ name: 'pkg-a', isDev: false }], [pkgA]);
 
       // then
       expect(result).toBeDefined();
@@ -123,7 +134,7 @@ describe('poetry-dep-graph-builder', () => {
       const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
 
       // when
-      build(rootPkg, [pkgA.name], [pkgA]);
+      build(rootPkg, [{ name: 'pkg-a', isDev: false }], [pkgA]);
 
       // then
       const expectedWarningMessage = `Could not find any lockfile metadata for package: ${missingPkg}. This package will not be represented in the dependency graph.`;


### PR DESCRIPTION
- [ ] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

In order to add further details to a node in the dep graph, add scope label defining 'dev' or 'prod'. Keeps this work in line with [npm-deps](https://github.com/snyk/nodejs-lockfile-parser/blob/f2e344da636ba161a8c7dbe7c8b6c113a234f82d/lib/dep-graph-builders/util.ts#L31-L32).

### Notes for the reviewer

- Branched off https://github.com/snyk/snyk-poetry-lockfile-parser/pull/16

### More information

- [OSM-12](https://snyksec.atlassian.net/browse/OSM-12)


[OSM-12]: https://snyksec.atlassian.net/browse/OSM-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ