### PR TITLE
fix: [OSM-15] handled toml parsing errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ commands:
       - run:
           name: Test
           command: npm test
+  test-coverage:
+    steps:
+      - run:
+          name: Test
+          command: npm run test:coverage
   release:
     steps:
       - run:
@@ -44,7 +49,18 @@ jobs:
     steps:
       - checkout
       - install
-      - test
+      # This is a workaround because coverage involves a library that does not support node 8 anymore
+      - when:
+          condition:
+            equal: ["8.17.0", << parameters.version >>]
+          steps:
+            - test
+      - when:
+          condition:
+            not: 
+              equal: ["8.17.0", << parameters.version >>]
+          steps:
+            - test-coverage
 
   release:
     resource_class: small

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/loki
+* @snyk/os-managed

--- a/lib/lock-file-parser.ts
+++ b/lib/lock-file-parser.ts
@@ -3,7 +3,12 @@ import * as toml from '@iarna/toml';
 export function packageSpecsFrom(
   lockFileContents: string,
 ): PoetryLockFileDependency[] {
-  const lockFile = toml.parse(lockFileContents) as unknown as PoetryLockFile;
+  let lockFile: PoetryLockFile;
+  try {
+    lockFile = toml.parse(lockFileContents) as unknown as PoetryLockFile;
+  } catch {
+    throw new LockFileNotValid();
+  }
 
   if (!lockFile.package) {
     throw new LockFileNotValid();

--- a/lib/manifest-parser.ts
+++ b/lib/manifest-parser.ts
@@ -20,9 +20,15 @@ export function getDependenciesFrom(
   manifestFileContents: string,
   includeDevDependencies: boolean,
 ): Dependency[] {
-  const manifest = toml.parse(
-    manifestFileContents,
-  ) as unknown as PoetryManifestType;
+  let manifest: PoetryManifestType;
+  try {
+    manifest = toml.parse(
+      manifestFileContents,
+    ) as unknown as PoetryManifestType;
+  } catch {
+    throw new ManifestFileNotValid();
+  }
+
   if (!manifest.tool?.poetry) {
     throw new ManifestFileNotValid();
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint": "npm run format:check && npm run lint:eslint",
     "lint:eslint": "eslint --color --cache 'lib/**/*.{js,ts}'",
     "test": "npm run test:unit",
-    "test:unit": "jest --coverage",
+    "test:unit": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "tsc-watch --onSuccess 'npm run test:unit'",
     "build": "tsc",
     "build-watch": "tsc -w",
@@ -36,10 +37,10 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
+    "@types/babel__traverse": "7.0.4",
     "@types/debug": "^4.1.5",
     "@types/jest": "^25.2.3",
     "@types/node": "^14",
-    "@types/babel__traverse": "7.0.4",
     "@typescript-eslint/eslint-plugin": "^3.7.0",
     "@typescript-eslint/parser": "^3.7.0",
     "eslint": "^7.0.0",

--- a/test/unit/lib/lock-file-parser.test.ts
+++ b/test/unit/lib/lock-file-parser.test.ts
@@ -4,6 +4,11 @@ import {
 } from '../../../lib/lock-file-parser';
 
 describe('when loading lockfile', () => {
+  it('should throw LockFileNotValid if toml parsing throws an error', () => {
+    const fileContents = `[[package]
+      category = 'main"`;
+    expect(() => packageSpecsFrom(fileContents)).toThrow(LockFileNotValid);
+  });
   it('should throw exception if package stanza not found', () => {
     expect(() => packageSpecsFrom('')).toThrow(LockFileNotValid);
   });

--- a/test/unit/lib/manifest-parser.test.ts
+++ b/test/unit/lib/manifest-parser.test.ts
@@ -6,6 +6,10 @@ import {
 
 describe('when loading manifest files', () => {
   describe('pkgInfoFrom', () => {
+    it('should throw ManifestFileNotValid if toml parsing throws an error', () => {
+      const fileContents = `[[tool]`;
+      expect(() => pkgInfoFrom(fileContents)).toThrow(ManifestFileNotValid);
+    });
     it('should return package info given the contents of a manifest', () => {
       const fileContents = `[tool.poetry]
         name = "poetry-fixtures-project"


### PR DESCRIPTION
Parsing errors thrown by toml should throw ManifestFileNotValid or LockFileNotValid.