### PR TITLE
fix: [OSM-441] Adjusting to reorganized error catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@snyk/error-catalog-nodejs-public": "^3.18.6",
+    "@snyk/error-catalog-nodejs-public": "^4.0.1",
     "@iarna/toml": "^2.2.5",
     "@snyk/cli-interface": "^2.9.2",
     "@snyk/dep-graph": "^2.3.0",


### PR DESCRIPTION
Updating `error-catalog` dependency due to some error catalog restructuring and adjusting changed errors accordingly.
