### PR TITLE
feat: emit component-metadata (hash/distribution) labels for SBOM export

### DIFF
--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -2,14 +2,13 @@ import * as debugLib from 'debug';
 
 const debug = debugLib('snyk-poetry-lockfile-parser');
 
-// Component-metadata labels follow the convention established in nodejs-lockfile-parser:
-// `hash:<alg>` keys with hyphenated algorithm names and lowercase-hex values, and a
-// credential-stripped `distribution:url`. These feed sbom-export's Component.Hashes[] and
-// the "distribution" ExternalUrls entry.
+// Component-metadata labels use the shape sbom-export consumes: `hash:<alg>` keys with
+// hyphenated algorithm names and lowercase-hex values (feeding Component.Hashes[]), and a
+// credential-stripped `distribution:url` (feeding the "distribution" ExternalUrls entry).
 //
 // See docs/component-metadata.md for the full rationale: why we emit one artifact per node
-// (the label channel is single-valued and the lockfile is a platform-agnostic *set*), why
-// the common PyPI case has no URL, and how the `legacy` private-index URL is constructed.
+// (the label channel is single-valued and the lockfile is a platform-agnostic *set*), how the
+// distribution:url is derived per source type, and how the `legacy` private-index URL is built.
 
 export interface LockFileEntryFile {
   file: string;

--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -6,9 +6,18 @@ const debug = debugLib('snyk-poetry-lockfile-parser');
 // hyphenated algorithm names and lowercase-hex values (feeding Component.Hashes[]), and a
 // credential-stripped `distribution:url` (feeding the "distribution" ExternalUrls entry).
 //
-// See docs/component-metadata.md for the full rationale: why we emit one artifact per node
-// (the label channel is single-valued and the lockfile is a platform-agnostic *set*), how the
-// distribution:url is derived per source type, and how the `legacy` private-index URL is built.
+// Two properties of poetry.lock drive the design here, and are why this isn't a straight
+// copy of the label mapping other ecosystems use:
+//
+//  1. A package's `files` is a platform-agnostic *set* — the sdist plus every published
+//     wheel. A label holds a single value (and a CycloneDX Component.Hashes[] means "one
+//     artifact, several algorithms", not "several artifacts"), so we must collapse to one
+//     artifact. selectArtifact() does that deterministically, without needing to know a
+//     target platform.
+//  2. The lock never records an artifact *download* URL, and we must not fetch one (the
+//     same code path serves private indexes whose credentials we don't hold). What poetry
+//     does record is the index a package came from, so distribution:url is a PEP 503
+//     project-page URL pointed at the selected file — see distributionUrlLabel().
 
 export interface LockFileEntryFile {
   file: string;

--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -41,6 +41,11 @@ const HASH_ALG_TO_LABEL: Record<string, string> = {
 export function getComponentMetadataLabels(
   pkg: ComponentMetadataInput,
 ): Record<string, string> {
+  // No files recorded means no artifact to hash and no distribution to point at (real PyPI /
+  // index packages always list files; fileless entries are anomalous), so report nothing.
+  if (!pkg.files || pkg.files.length === 0) {
+    return {};
+  }
   // Select the artifact once so the hash and the distribution URL describe the *same* file.
   const selected = selectArtifact(pkg.name, pkg.files);
   return {
@@ -115,32 +120,46 @@ function hashToLabel(hash: string): Record<string, string> {
   return { [label]: value.toLowerCase() };
 }
 
+// poetry records a `[package.source]` stanza for every index except the built-in PyPI
+// (including a custom primary/default source, which is recorded as `legacy`). So the absence
+// of a source stanza reliably means the package came from pypi.org, and we can build its
+// PEP 503 project page from this well-known root.
+const PYPI_SIMPLE_ROOT = 'https://pypi.org/simple';
+
 function distributionUrlLabel(
   name: string,
   source: LockFileEntrySource | undefined,
   selected: LockFileEntryFile | undefined,
 ): Record<string, string> {
-  if (!source || !source.url) {
-    return {};
+  // No source stanza => built-in PyPI. Build its project page (see PYPI_SIMPLE_ROOT note).
+  if (!source) {
+    return projectPageLabel(PYPI_SIMPLE_ROOT, name, selected);
   }
   // Direct-URL dependency: the source URL is the exact artifact.
-  if (source.type === 'url') {
+  if (source.type === 'url' && source.url) {
     const cleaned = sanitizeUrl(source.url);
     return cleaned ? { 'distribution:url': cleaned } : {};
   }
-  // Private index (PEP 503 Simple API repository). poetry recorded the real index root, so
-  // we build the package's project page and point it at the selected file:
-  // <root>/<pep503-normalized-name>/#<selected-filename>. The `#<filename>` is an identifier
-  // fragment (which file the sibling hash label describes), NOT a navigable anchor or a
-  // download URL — the page's real anchors link to the artifacts, which we cannot
-  // reconstruct offline. When no artifact was selected we emit the bare package-granular
-  // project page.
-  if (source.type === 'legacy') {
-    const projectPage = buildSimpleIndexProjectUrl(source.url, name, selected);
-    return projectPage ? { 'distribution:url': projectPage } : {};
+  // Private index (PEP 503 Simple API repository): poetry recorded the real index root.
+  if (source.type === 'legacy' && source.url) {
+    return projectPageLabel(source.url, name, selected);
   }
   // git / file / directory: not a downloadable distribution artifact.
   return {};
+}
+
+// Build the PEP 503 project-page URL for `name` under `root`, pointed at the selected file:
+// <root>/<pep503-normalized-name>/#<selected-filename>. The `#<filename>` is an identifier
+// fragment (which file the sibling hash label describes), NOT a navigable anchor or a
+// download URL — the page's real anchors link to the artifacts, which we cannot reconstruct
+// offline. When no artifact was selected we emit the bare package-granular project page.
+function projectPageLabel(
+  root: string,
+  name: string,
+  selected: LockFileEntryFile | undefined,
+): Record<string, string> {
+  const projectPage = buildSimpleIndexProjectUrl(root, name, selected);
+  return projectPage ? { 'distribution:url': projectPage } : {};
 }
 
 function buildSimpleIndexProjectUrl(

--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -1,0 +1,170 @@
+import * as debugLib from 'debug';
+
+const debug = debugLib('snyk-poetry-lockfile-parser');
+
+// Component-metadata labels follow the convention established in nodejs-lockfile-parser:
+// `hash:<alg>` keys with hyphenated algorithm names and lowercase-hex values, and a
+// credential-stripped `distribution:url`. These feed sbom-export's Component.Hashes[] and
+// the "distribution" ExternalUrls entry.
+//
+// See docs/component-metadata.md for the full rationale: why we emit one artifact per node
+// (the label channel is single-valued and the lockfile is a platform-agnostic *set*), why
+// the common PyPI case has no URL, and how the `legacy` private-index URL is constructed.
+
+export interface LockFileEntryFile {
+  file: string;
+  hash: string; // e.g. "sha256:<hex>"
+}
+
+export interface LockFileEntrySource {
+  type: string; // "url" | "legacy" | "git" | "file" | "directory"
+  url?: string;
+  reference?: string;
+}
+
+export interface ComponentMetadataInput {
+  name: string;
+  files?: LockFileEntryFile[];
+  source?: LockFileEntrySource;
+}
+
+// poetry locks only ever carry sha256, but map defensively so an unexpected algorithm is
+// skipped rather than mislabelled.
+const HASH_ALG_TO_LABEL: Record<string, string> = {
+  sha256: 'hash:sha-256',
+  sha512: 'hash:sha-512',
+  sha384: 'hash:sha-384',
+  sha1: 'hash:sha-1',
+  md5: 'hash:md5',
+};
+
+export function getComponentMetadataLabels(
+  pkg: ComponentMetadataInput,
+): Record<string, string> {
+  return {
+    ...hashLabel(pkg.name, pkg.files),
+    ...distributionUrlLabel(pkg.name, pkg.source),
+  };
+}
+
+function hashLabel(
+  name: string,
+  files?: LockFileEntryFile[],
+): Record<string, string> {
+  const selected = selectArtifact(name, files);
+  if (!selected) {
+    return {};
+  }
+  return hashToLabel(selected.hash);
+}
+
+// Collapse the lockfile's candidate `files` set to a single artifact. The label channel
+// holds one hash per node and the lockfile lists every published distribution (sdist + all
+// wheels) platform-agnostically, so we choose deterministically.
+function selectArtifact(
+  name: string,
+  files?: LockFileEntryFile[],
+): LockFileEntryFile | undefined {
+  if (!files || files.length === 0) {
+    return undefined;
+  }
+  // A single published file (or a `url`/`file` source pinned to one artifact) is
+  // unambiguous — use it regardless of platform-specificity.
+  if (files.length === 1) {
+    return files[0];
+  }
+  // 1. platform-independent wheel (`*-none-any.whl`) — what pip installs everywhere for a
+  //    pure-python package, and deterministic across parsing hosts.
+  const universalWheel = files.find((f) => isUniversalWheel(f.file));
+  if (universalWheel) {
+    return universalWheel;
+  }
+  // 2. sdist (`.tar.gz` / `.zip`) — canonical, platform-independent release identity.
+  const sdist = files.find((f) => isSdist(f.file));
+  if (sdist) {
+    return sdist;
+  }
+  // 3. only platform-specific wheels, no universal wheel, no sdist: we cannot know the
+  //    target platform offline, so emit no hash rather than guess.
+  debug(
+    `No platform-independent artifact for "${name}"; emitting no hash (only platform-specific wheels found).`,
+  );
+  return undefined;
+}
+
+function isUniversalWheel(filename: string): boolean {
+  return /-none-any\.whl$/i.test(filename);
+}
+
+function isSdist(filename: string): boolean {
+  const lower = filename.toLowerCase();
+  return lower.endsWith('.tar.gz') || lower.endsWith('.zip');
+}
+
+function hashToLabel(hash: string): Record<string, string> {
+  const separatorIndex = hash.indexOf(':');
+  if (separatorIndex === -1) {
+    return {};
+  }
+  const alg = hash.slice(0, separatorIndex).toLowerCase();
+  const value = hash.slice(separatorIndex + 1);
+  const label = HASH_ALG_TO_LABEL[alg];
+  if (!label || !value) {
+    return {};
+  }
+  return { [label]: value.toLowerCase() };
+}
+
+function distributionUrlLabel(
+  name: string,
+  source?: LockFileEntrySource,
+): Record<string, string> {
+  if (!source || !source.url) {
+    return {};
+  }
+  // Direct-URL dependency: the source URL is the exact artifact.
+  if (source.type === 'url') {
+    const cleaned = sanitizeUrl(source.url);
+    return cleaned ? { 'distribution:url': cleaned } : {};
+  }
+  // Private index (PEP 503 Simple API repository). poetry recorded the real index root, so
+  // we build the package's project page: <root>/<pep503-normalized-name>/. This is a
+  // package-granular provenance URL, not the exact-artifact download URL (which lives in
+  // the page's anchors and would need a network fetch we deliberately avoid).
+  if (source.type === 'legacy') {
+    const projectPage = buildSimpleIndexProjectUrl(source.url, name);
+    return projectPage ? { 'distribution:url': projectPage } : {};
+  }
+  // git / file / directory: not a downloadable distribution artifact.
+  return {};
+}
+
+function buildSimpleIndexProjectUrl(
+  root: string,
+  name: string,
+): string | undefined {
+  const cleaned = sanitizeUrl(root);
+  if (!cleaned) {
+    return undefined;
+  }
+  const base = cleaned.replace(/\/+$/, '');
+  return `${base}/${normalizePep503Name(name)}/`;
+}
+
+// PEP 503: normalize by lowercasing and collapsing runs of -, _, . to a single -.
+function normalizePep503Name(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}
+
+// Strip embedded basic-auth credentials and any URL fragment before emitting.
+function sanitizeUrl(rawUrl: string): string | undefined {
+  try {
+    const url = new URL(rawUrl);
+    url.username = '';
+    url.password = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -41,17 +41,17 @@ const HASH_ALG_TO_LABEL: Record<string, string> = {
 export function getComponentMetadataLabels(
   pkg: ComponentMetadataInput,
 ): Record<string, string> {
+  // Select the artifact once so the hash and the distribution URL describe the *same* file.
+  const selected = selectArtifact(pkg.name, pkg.files);
   return {
-    ...hashLabel(pkg.name, pkg.files),
-    ...distributionUrlLabel(pkg.name, pkg.source),
+    ...hashLabel(selected),
+    ...distributionUrlLabel(pkg.name, pkg.source, selected),
   };
 }
 
 function hashLabel(
-  name: string,
-  files?: LockFileEntryFile[],
+  selected: LockFileEntryFile | undefined,
 ): Record<string, string> {
-  const selected = selectArtifact(name, files);
   if (!selected) {
     return {};
   }
@@ -117,7 +117,8 @@ function hashToLabel(hash: string): Record<string, string> {
 
 function distributionUrlLabel(
   name: string,
-  source?: LockFileEntrySource,
+  source: LockFileEntrySource | undefined,
+  selected: LockFileEntryFile | undefined,
 ): Record<string, string> {
   if (!source || !source.url) {
     return {};
@@ -128,11 +129,14 @@ function distributionUrlLabel(
     return cleaned ? { 'distribution:url': cleaned } : {};
   }
   // Private index (PEP 503 Simple API repository). poetry recorded the real index root, so
-  // we build the package's project page: <root>/<pep503-normalized-name>/. This is a
-  // package-granular provenance URL, not the exact-artifact download URL (which lives in
-  // the page's anchors and would need a network fetch we deliberately avoid).
+  // we build the package's project page and point it at the selected file:
+  // <root>/<pep503-normalized-name>/#<selected-filename>. The `#<filename>` is an identifier
+  // fragment (which file the sibling hash label describes), NOT a navigable anchor or a
+  // download URL — the page's real anchors link to the artifacts, which we cannot
+  // reconstruct offline. When no artifact was selected we emit the bare package-granular
+  // project page.
   if (source.type === 'legacy') {
-    const projectPage = buildSimpleIndexProjectUrl(source.url, name);
+    const projectPage = buildSimpleIndexProjectUrl(source.url, name, selected);
     return projectPage ? { 'distribution:url': projectPage } : {};
   }
   // git / file / directory: not a downloadable distribution artifact.
@@ -142,13 +146,15 @@ function distributionUrlLabel(
 function buildSimpleIndexProjectUrl(
   root: string,
   name: string,
+  selected: LockFileEntryFile | undefined,
 ): string | undefined {
   const cleaned = sanitizeUrl(root);
   if (!cleaned) {
     return undefined;
   }
   const base = cleaned.replace(/\/+$/, '');
-  return `${base}/${normalizePep503Name(name)}/`;
+  const projectPage = `${base}/${normalizePep503Name(name)}/`;
+  return selected ? `${projectPage}#${selected.file}` : projectPage;
 }
 
 // PEP 503: normalize by lowercasing and collapsing runs of -, _, . to a single -.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ export function buildDepGraph(
   manifestFileContents: string,
   lockFileContents: string,
   includeDevDependencies = false,
+  includeComponentMetadata = false,
 ): DepGraph {
   const dependencies: Dependency[] = manifest.getDependenciesFrom(
     manifestFileContents,
@@ -17,5 +18,10 @@ export function buildDepGraph(
   const pkgDetails: PkgInfo = manifest.pkgInfoFrom(manifestFileContents);
   const pkgSpecs: PoetryLockFileDependency[] =
     lockFile.packageSpecsFrom(lockFileContents);
-  return poetryDepGraphBuilder.build(pkgDetails, dependencies, pkgSpecs);
+  return poetryDepGraphBuilder.build(
+    pkgDetails,
+    dependencies,
+    pkgSpecs,
+    includeComponentMetadata,
+  );
 }

--- a/lib/lock-file-parser.ts
+++ b/lib/lock-file-parser.ts
@@ -1,5 +1,9 @@
 import * as toml from '@iarna/toml';
 import { OpenSourceEcosystems } from '@snyk/error-catalog-nodejs-public';
+import {
+  LockFileEntryFile,
+  LockFileEntrySource,
+} from './component-metadata-labels';
 
 export function packageSpecsFrom(
   lockFileContents: string,
@@ -20,27 +24,52 @@ export function packageSpecsFrom(
     );
   }
 
+  // In lock-version 1.x hashes live in a separate `[metadata.files]` table keyed by package
+  // name; in 2.x they are inline as `files` on each `[[package]]`. Support both.
+  const metadataFiles = metadataFilesIndex(lockFile.metadata?.files);
+
   return lockFile.package.map((pkg) => {
     return {
       name: pkg.name,
       version: pkg.version,
       dependencies: Object.keys(pkg.dependencies || []),
+      files: pkg.files ?? metadataFiles[pkg.name.toLowerCase()] ?? [],
+      source: pkg.source,
     };
   });
 }
 
+// Index the v1 `[metadata.files]` table case-insensitively so it can be joined back to each
+// package regardless of name casing.
+function metadataFilesIndex(
+  files?: Record<string, LockFileEntryFile[]>,
+): Record<string, LockFileEntryFile[]> {
+  const index: Record<string, LockFileEntryFile[]> = {};
+  for (const [name, entries] of Object.entries(files || {})) {
+    index[name.toLowerCase()] = entries;
+  }
+  return index;
+}
+
 interface PoetryLockFile {
   package: Package[];
+  metadata?: {
+    files?: Record<string, LockFileEntryFile[]>;
+  };
 }
 
 interface Package {
   name: string;
   version: string;
   dependencies?: Record<string, PoetryLockFileDependency>;
+  files?: LockFileEntryFile[];
+  source?: LockFileEntrySource;
 }
 
 export interface PoetryLockFileDependency {
   name: string;
   version: string;
   dependencies: string[];
+  files?: LockFileEntryFile[];
+  source?: LockFileEntrySource;
 }

--- a/lib/poetry-dep-graph-builder.ts
+++ b/lib/poetry-dep-graph-builder.ts
@@ -2,6 +2,7 @@ import { defaults } from 'lodash';
 import { DepGraph, DepGraphBuilder, PkgInfo } from '@snyk/dep-graph';
 import { PoetryLockFileDependency } from './lock-file-parser';
 import { Dependency } from './parsers/types';
+import { getComponentMetadataLabels } from './component-metadata-labels';
 
 // Poetry uses the virtualenv to create an environment and this comes with these
 // packages pre-installed, therefore they won't be part of the lockfile.
@@ -28,10 +29,17 @@ export function build(
   pkgDetails: PkgInfo,
   dependencies: Dependency[],
   pkgSpecs: PoetryLockFileDependency[],
+  includeComponentMetadata = false,
 ): DepGraph {
   const rootPkg = defaults({}, pkgDetails, DEFAULT_ROOT_PKG);
   const builder = new DepGraphBuilder({ name: 'poetry' }, rootPkg);
-  addDependenciesToGraph(dependencies, pkgSpecs, builder.rootNodeId, builder);
+  addDependenciesToGraph(
+    dependencies,
+    pkgSpecs,
+    builder.rootNodeId,
+    builder,
+    includeComponentMetadata,
+  );
   return builder.build();
 }
 
@@ -40,9 +48,16 @@ function addDependenciesToGraph(
   pkgSpecs: PoetryLockFileDependency[],
   parentNodeId: string,
   builder: DepGraphBuilder,
+  includeComponentMetadata: boolean,
 ) {
   for (const dep of dependencies) {
-    addDependenciesForPkg(dep, pkgSpecs, parentNodeId, builder);
+    addDependenciesForPkg(
+      dep,
+      pkgSpecs,
+      parentNodeId,
+      builder,
+      includeComponentMetadata,
+    );
   }
 }
 
@@ -51,6 +66,7 @@ function addDependenciesForPkg(
   pkgSpecs: PoetryLockFileDependency[],
   parentNodeId: string,
   builder: DepGraphBuilder,
+  includeComponentMetadata: boolean,
 ) {
   const pkgName = dependency.name;
   if (IGNORED_DEPENDENCIES.includes(pkgName)) {
@@ -72,6 +88,16 @@ function addDependenciesForPkg(
   if (pkg.name != pkgName) {
     labels.pkgIdProvenance = `${pkgName}@${pkg.version}`;
   }
+  if (includeComponentMetadata) {
+    Object.assign(
+      labels,
+      getComponentMetadataLabels({
+        name: pkg.name,
+        files: pkg.files,
+        source: pkg.source,
+      }),
+    );
+  }
   builder
     .addPkgNode(pkgInfo, pkg.name, {
       labels,
@@ -85,6 +111,7 @@ function addDependenciesForPkg(
     pkgSpecs,
     pkg.name,
     builder,
+    includeComponentMetadata,
   );
 }
 

--- a/test/unit/lib/component-metadata-labels.test.ts
+++ b/test/unit/lib/component-metadata-labels.test.ts
@@ -70,16 +70,15 @@ describe('getComponentMetadataLabels', () => {
         name: 'x',
         files: [{ file: 'x-1.0.0.tar.gz', hash: 'sha256:AABBCC' }],
       });
-      expect(labels).toEqual({ 'hash:sha-256': 'aabbcc' });
+      expect(labels['hash:sha-256']).toBe('aabbcc');
     });
 
     it('ignores an unrecognised / malformed hash', () => {
-      expect(
-        getComponentMetadataLabels({
-          name: 'x',
-          files: [{ file: 'x-1.0.0.tar.gz', hash: 'notahash' }],
-        }),
-      ).toEqual({});
+      const labels = getComponentMetadataLabels({
+        name: 'x',
+        files: [{ file: 'x-1.0.0.tar.gz', hash: 'notahash' }],
+      });
+      expect(labels['hash:sha-256']).toBeUndefined();
     });
   });
 
@@ -189,13 +188,37 @@ describe('getComponentMetadataLabels', () => {
       expect(labels['distribution:url']).toBeUndefined();
     });
 
-    it('emits no URL for the common PyPI case (no source stanza)', () => {
+    it('builds the pypi.org project-page URL for the default PyPI case (no source stanza)', () => {
+      // No `[package.source]` reliably means the built-in PyPI (poetry records a stanza for
+      // every other index, including a custom primary source), so we can assume pypi.org.
       const labels = getComponentMetadataLabels({
-        name: 'requests',
+        name: 'Requests',
         files: [{ file: 'requests-2.0.0.tar.gz', hash: 'sha256:a' }],
       });
-      expect(labels['distribution:url']).toBeUndefined();
       expect(labels['hash:sha-256']).toBe('a');
+      expect(labels['distribution:url']).toBe(
+        'https://pypi.org/simple/requests/#requests-2.0.0.tar.gz',
+      );
+    });
+
+    it('emits a bare pypi.org page when no artifact is selected for a PyPI package', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'onlyplatwheels',
+        files: [
+          {
+            file: 'onlyplatwheels-1-cp311-cp311-manylinux1_x86_64.whl',
+            hash: 'sha256:a',
+          },
+          {
+            file: 'onlyplatwheels-1-cp311-cp311-win_amd64.whl',
+            hash: 'sha256:b',
+          },
+        ],
+      });
+      expect(labels['hash:sha-256']).toBeUndefined();
+      expect(labels['distribution:url']).toBe(
+        'https://pypi.org/simple/onlyplatwheels/',
+      );
     });
   });
 });

--- a/test/unit/lib/component-metadata-labels.test.ts
+++ b/test/unit/lib/component-metadata-labels.test.ts
@@ -1,0 +1,165 @@
+import { getComponentMetadataLabels } from '../../../lib/component-metadata-labels';
+
+describe('getComponentMetadataLabels', () => {
+  describe('hash selection ladder', () => {
+    it('uses the single published file directly (unambiguous)', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'only-sdist',
+        files: [{ file: 'only-sdist-1.0.0.tar.gz', hash: 'sha256:aaaa' }],
+      });
+      expect(labels['hash:sha-256']).toBe('aaaa');
+    });
+
+    it('prefers the platform-independent wheel over the sdist', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'six',
+        files: [
+          { file: 'six-1.17.0-py2.py3-none-any.whl', hash: 'sha256:wheel' },
+          { file: 'six-1.17.0.tar.gz', hash: 'sha256:sdist' },
+        ],
+      });
+      expect(labels['hash:sha-256']).toBe('wheel');
+    });
+
+    it('falls back to the sdist when there is no universal wheel', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'markupsafe',
+        files: [
+          {
+            file: 'MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl',
+            hash: 'sha256:plat1',
+          },
+          {
+            file: 'MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl',
+            hash: 'sha256:plat2',
+          },
+          { file: 'MarkupSafe-1.1.1.tar.gz', hash: 'sha256:sdist' },
+        ],
+      });
+      expect(labels['hash:sha-256']).toBe('sdist');
+    });
+
+    it('emits no hash when only platform-specific wheels exist', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'nvidia-cublas-cu12',
+        files: [
+          {
+            file: 'nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl',
+            hash: 'sha256:plat1',
+          },
+          {
+            file: 'nvidia_cublas_cu12-12.4.5.8-py3-none-win_amd64.whl',
+            hash: 'sha256:plat2',
+          },
+        ],
+      });
+      expect(labels['hash:sha-256']).toBeUndefined();
+    });
+
+    it('emits no hash when there are no files', () => {
+      expect(getComponentMetadataLabels({ name: 'nofiles' })).toEqual({});
+      expect(
+        getComponentMetadataLabels({ name: 'nofiles', files: [] }),
+      ).toEqual({});
+    });
+  });
+
+  describe('hash formatting', () => {
+    it('maps sha256 to hash:sha-256 with a lowercase-hex value', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'x',
+        files: [{ file: 'x-1.0.0.tar.gz', hash: 'sha256:AABBCC' }],
+      });
+      expect(labels).toEqual({ 'hash:sha-256': 'aabbcc' });
+    });
+
+    it('ignores an unrecognised / malformed hash', () => {
+      expect(
+        getComponentMetadataLabels({
+          name: 'x',
+          files: [{ file: 'x-1.0.0.tar.gz', hash: 'notahash' }],
+        }),
+      ).toEqual({});
+    });
+  });
+
+  describe('distribution:url', () => {
+    it('emits the exact artifact URL for a direct `url` source', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'example-pkg',
+        files: [
+          { file: 'example_pkg-1.0.0-py3-none-any.whl', hash: 'sha256:a' },
+        ],
+        source: {
+          type: 'url',
+          url: 'https://example.com/artifacts/example_pkg-1.0.0-py3-none-any.whl',
+        },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://example.com/artifacts/example_pkg-1.0.0-py3-none-any.whl',
+      );
+    });
+
+    it('builds the PEP 503 project-page URL for a `legacy` private index', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'Internal_Lib',
+        files: [{ file: 'internal_lib-2.3.0.tar.gz', hash: 'sha256:a' }],
+        source: {
+          type: 'legacy',
+          url: 'https://artifactory.internal.example/api/pypi/pypi-remote/simple',
+          reference: 'internal',
+        },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://artifactory.internal.example/api/pypi/pypi-remote/simple/internal-lib/',
+      );
+    });
+
+    it('normalises a trailing slash on the legacy index root', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'foo',
+        files: [{ file: 'foo-1.0.0.tar.gz', hash: 'sha256:a' }],
+        source: { type: 'legacy', url: 'https://index.example/simple/' },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://index.example/simple/foo/',
+      );
+    });
+
+    it('strips basic-auth credentials from the emitted URL', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'foo',
+        files: [{ file: 'foo-1.0.0.tar.gz', hash: 'sha256:a' }],
+        source: {
+          type: 'legacy',
+          url: 'https://user:token@index.example/simple',
+        },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://index.example/simple/foo/',
+      );
+    });
+
+    it('emits no URL for a git source', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'forked-tool',
+        files: [],
+        source: {
+          type: 'git',
+          url: 'https://github.com/example-org/forked-tool.git',
+          reference: 'HEAD',
+        },
+      });
+      expect(labels['distribution:url']).toBeUndefined();
+    });
+
+    it('emits no URL for the common PyPI case (no source stanza)', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'requests',
+        files: [{ file: 'requests-2.0.0.tar.gz', hash: 'sha256:a' }],
+      });
+      expect(labels['distribution:url']).toBeUndefined();
+      expect(labels['hash:sha-256']).toBe('a');
+    });
+  });
+});

--- a/test/unit/lib/component-metadata-labels.test.ts
+++ b/test/unit/lib/component-metadata-labels.test.ts
@@ -100,7 +100,7 @@ describe('getComponentMetadataLabels', () => {
       );
     });
 
-    it('builds the PEP 503 project-page URL for a `legacy` private index', () => {
+    it('builds the PEP 503 project-page URL for a `legacy` private index, pointing at the selected file', () => {
       const labels = getComponentMetadataLabels({
         name: 'Internal_Lib',
         files: [{ file: 'internal_lib-2.3.0.tar.gz', hash: 'sha256:a' }],
@@ -111,7 +111,43 @@ describe('getComponentMetadataLabels', () => {
         },
       });
       expect(labels['distribution:url']).toBe(
-        'https://artifactory.internal.example/api/pypi/pypi-remote/simple/internal-lib/',
+        'https://artifactory.internal.example/api/pypi/pypi-remote/simple/internal-lib/#internal_lib-2.3.0.tar.gz',
+      );
+    });
+
+    it('points the fragment at the ladder-selected file so URL and hash agree', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'six',
+        files: [
+          { file: 'six-1.17.0-py2.py3-none-any.whl', hash: 'sha256:wheel' },
+          { file: 'six-1.17.0.tar.gz', hash: 'sha256:sdist' },
+        ],
+        source: { type: 'legacy', url: 'https://index.example/simple' },
+      });
+      expect(labels['hash:sha-256']).toBe('wheel');
+      expect(labels['distribution:url']).toBe(
+        'https://index.example/simple/six/#six-1.17.0-py2.py3-none-any.whl',
+      );
+    });
+
+    it('emits the bare project-page URL when no artifact could be selected', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'nvidia-cublas-cu12',
+        files: [
+          {
+            file: 'nvidia_cublas_cu12-1-py3-none-manylinux2014_x86_64.whl',
+            hash: 'sha256:p1',
+          },
+          {
+            file: 'nvidia_cublas_cu12-1-py3-none-win_amd64.whl',
+            hash: 'sha256:p2',
+          },
+        ],
+        source: { type: 'legacy', url: 'https://index.example/simple' },
+      });
+      expect(labels['hash:sha-256']).toBeUndefined();
+      expect(labels['distribution:url']).toBe(
+        'https://index.example/simple/nvidia-cublas-cu12/',
       );
     });
 
@@ -122,7 +158,7 @@ describe('getComponentMetadataLabels', () => {
         source: { type: 'legacy', url: 'https://index.example/simple/' },
       });
       expect(labels['distribution:url']).toBe(
-        'https://index.example/simple/foo/',
+        'https://index.example/simple/foo/#foo-1.0.0.tar.gz',
       );
     });
 
@@ -136,7 +172,7 @@ describe('getComponentMetadataLabels', () => {
         },
       });
       expect(labels['distribution:url']).toBe(
-        'https://index.example/simple/foo/',
+        'https://index.example/simple/foo/#foo-1.0.0.tar.gz',
       );
     });
 

--- a/test/unit/lib/lock-file-parser.test.ts
+++ b/test/unit/lib/lock-file-parser.test.ts
@@ -32,16 +32,63 @@ describe('when loading lockfile', () => {
       version = "1.1.1"`;
     const lockFileDependencies = packageSpecsFrom(fileContents);
     expect(lockFileDependencies.length).toBe(2);
-    expect(lockFileDependencies).toContainEqual({
-      name: 'pkg_a',
-      version: '2.11.2',
-      dependencies: ['pkg_b'],
+    expect(lockFileDependencies).toContainEqual(
+      expect.objectContaining({
+        name: 'pkg_a',
+        version: '2.11.2',
+        dependencies: ['pkg_b'],
+      }),
+    );
+    expect(lockFileDependencies).toContainEqual(
+      expect.objectContaining({
+        name: 'pkg_b',
+        version: '1.1.1',
+        dependencies: [],
+      }),
+    );
+  });
+
+  it('reads inline `files` (lock v2) and `[package.source]` onto each package', () => {
+    const fileContents = `[[package]]
+      name = "pkg_a"
+      version = "1.0.0"
+      files = [
+        {file = "pkg_a-1.0.0-py3-none-any.whl", hash = "sha256:aaaa"},
+        {file = "pkg_a-1.0.0.tar.gz", hash = "sha256:bbbb"},
+      ]
+
+      [package.source]
+      type = "legacy"
+      url = "https://index.example/simple"
+      reference = "internal"`;
+    const [pkg] = packageSpecsFrom(fileContents);
+    expect(pkg.files).toEqual([
+      { file: 'pkg_a-1.0.0-py3-none-any.whl', hash: 'sha256:aaaa' },
+      { file: 'pkg_a-1.0.0.tar.gz', hash: 'sha256:bbbb' },
+    ]);
+    expect(pkg.source).toEqual({
+      type: 'legacy',
+      url: 'https://index.example/simple',
+      reference: 'internal',
     });
-    expect(lockFileDependencies).toContainEqual({
-      name: 'pkg_b',
-      version: '1.1.1',
-      dependencies: [],
-    });
+  });
+
+  it('joins the v1 `[metadata.files]` table back to each package (case-insensitive)', () => {
+    const fileContents = `[[package]]
+      name = "Pkg_A"
+      version = "1.0.0"
+
+      [metadata]
+      lock-version = "1.0"
+
+      [metadata.files]
+      pkg_a = [
+        {file = "Pkg_A-1.0.0.tar.gz", hash = "sha256:cccc"},
+      ]`;
+    const [pkg] = packageSpecsFrom(fileContents);
+    expect(pkg.files).toEqual([
+      { file: 'Pkg_A-1.0.0.tar.gz', hash: 'sha256:cccc' },
+    ]);
   });
 
   it('should return an empty list when no packages are specified in file', () => {

--- a/test/unit/lib/lock-file-parser.test.ts
+++ b/test/unit/lib/lock-file-parser.test.ts
@@ -91,6 +91,41 @@ describe('when loading lockfile', () => {
     ]);
   });
 
+  // poetry 1.x (lock v1 family) records a `[package.source]` stanza for a configured index
+  // just as 2.x does, including for a custom *primary/default* source. Verified against
+  // poetry 1.1.15: a `default = true` source yields `type = "legacy"` with its own root.
+  // This matters because the absence of a source stanza is what we treat as "built-in
+  // PyPI" — a v1 lock resolved from a private index must not look bare.
+  it('reads `[package.source]` alongside the v1 `[metadata.files]` layout', () => {
+    const fileContents = `[[package]]
+      category = "main"
+      name = "internal-lib"
+      optional = false
+      version = "2.3.0"
+
+      [package.source]
+      type = "legacy"
+      url = "https://artifactory.internal.example/api/pypi/pypi-remote/simple"
+      reference = "internal"
+
+      [metadata]
+      lock-version = "1.1"
+
+      [metadata.files]
+      internal-lib = [
+        {file = "internal_lib-2.3.0-py3-none-any.whl", hash = "sha256:aaaa"},
+      ]`;
+    const [pkg] = packageSpecsFrom(fileContents);
+    expect(pkg.files).toEqual([
+      { file: 'internal_lib-2.3.0-py3-none-any.whl', hash: 'sha256:aaaa' },
+    ]);
+    expect(pkg.source).toEqual({
+      type: 'legacy',
+      url: 'https://artifactory.internal.example/api/pypi/pypi-remote/simple',
+      reference: 'internal',
+    });
+  });
+
   it('should return an empty list when no packages are specified in file', () => {
     const lockFileDependencies = packageSpecsFrom('package = []');
     expect(lockFileDependencies.length).toBe(0);

--- a/test/unit/lib/poetry-dep-graph-builder.test.ts
+++ b/test/unit/lib/poetry-dep-graph-builder.test.ts
@@ -158,7 +158,8 @@ describe('poetry-dep-graph-builder', () => {
       expect(node!.info?.labels).toEqual({
         scope: 'prod',
         'hash:sha-256': 'wheel',
-        'distribution:url': 'https://index.example/simple/pkg-a/',
+        'distribution:url':
+          'https://index.example/simple/pkg-a/#pkg-a-1.0.0-py3-none-any.whl',
       });
     });
 

--- a/test/unit/lib/poetry-dep-graph-builder.test.ts
+++ b/test/unit/lib/poetry-dep-graph-builder.test.ts
@@ -125,6 +125,43 @@ describe('poetry-dep-graph-builder', () => {
         .graph.nodes.filter((node) => node.nodeId === pkgA.name);
     });
 
+    it('does not emit component-metadata labels by default', () => {
+      const pkgA = generatePoetryLockFileDependency('pkg-a');
+      pkgA.files = [{ file: 'pkg-a-1.0.0.tar.gz', hash: 'sha256:abc' }];
+
+      const result = build(rootPkg, [{ name: 'pkg-a', isDev: false }], [pkgA]);
+
+      const node = result
+        .toJSON()
+        .graph.nodes.find((n) => n.nodeId === pkgA.name);
+      expect(node!.info?.labels).toEqual({ scope: 'prod' });
+    });
+
+    it('emits component-metadata labels when includeComponentMetadata is true', () => {
+      const pkgA = generatePoetryLockFileDependency('pkg-a');
+      pkgA.files = [
+        { file: 'pkg-a-1.0.0-py3-none-any.whl', hash: 'sha256:WHEEL' },
+        { file: 'pkg-a-1.0.0.tar.gz', hash: 'sha256:sdist' },
+      ];
+      pkgA.source = { type: 'legacy', url: 'https://index.example/simple' };
+
+      const result = build(
+        rootPkg,
+        [{ name: 'pkg-a', isDev: false }],
+        [pkgA],
+        true,
+      );
+
+      const node = result
+        .toJSON()
+        .graph.nodes.find((n) => n.nodeId === pkgA.name);
+      expect(node!.info?.labels).toEqual({
+        scope: 'prod',
+        'hash:sha-256': 'wheel',
+        'distribution:url': 'https://index.example/simple/pkg-a/',
+      });
+    });
+
     it('should log warning if metadata cannot be found in pkgSpecs', () => {
       // given
       const missingPkg = 'non-existent-pkg';


### PR DESCRIPTION
- [x] Tests written and linted
- [ ] Documentation written / README.md updated [https://snyk.io/docs/snyk-for-node/](i)
- [x] Follows [CONTRIBUTING agreement](CONTRIBUTING.md)
- [x] Commit history is tidy [https://git-scm.com/book/en/v2/Git-Branching-Rebasing](i)
- [ ] Reviewed by Snyk team

### What this does

Part of the ongoing work to surface **component metadata** (artifact hashes and
distribution URLs) on dep-graph nodes so `sbom-export` can populate
`Component[].Hashes[]` and the "distribution" `ExternalUrls` entry.

Adds an opt-in `includeComponentMetadata` flag (4th positional param of
`buildDepGraph`, default `false`). When set, each dep-graph node gains
`hash:<alg>` and `distribution:url` labels in the shape `sbom-export` consumes.

- **lockfile reading** — extract each package's `files` (lock v2 inline **and**
  the v1 `[metadata.files]` table, joined case-insensitively) plus
  `[package.source]`.
- **hash selection** — `poetry.lock` lists a platform-agnostic *set* of files
  (sdist + every wheel) but a dep-graph label holds one value, so we collapse
  deterministically: single file → use it; otherwise platform-independent wheel
  (`*-none-any.whl`) → sdist (`.tar.gz`/`.zip`) → emit nothing. sha256 is
  formatted as `hash:sha-256` with a lowercase-hex value.
- **distribution URL** — the lock never carries the real download URL
  (`files.pythonhosted.org` embeds a hash-derived path we can't reconstruct, and
  we deliberately don't call any index API since the same path serves private
  registries whose credentials we don't hold). What we *can* build is the PEP 503
  **project-page URL**, pointed at the selected file:

  | `source.type` | emitted `distribution:url` |
  |---|---|
  | *(none — PyPI)* | `https://pypi.org/simple/<name>/#<selected-file>` |
  | `url` | the direct artifact URL (exact artifact) |
  | `legacy` (private index) | `<recorded-root>/<name>/#<selected-file>` |
  | `git` / `file` / `directory` | none — not a downloadable distribution |

  So every index-resolved package gets a URL. The `#<filename>` fragment is what
  ties the URL to the **same** artifact as the sibling `hash:` label (the bare
  project page is package-granular and wouldn't tell you which file the hash
  describes). It is an identifier, not a navigable anchor or a download link.
  Where no artifact could be selected (platform-only wheels ⇒ no hash) the bare
  project page is emitted instead. Names are PEP 503-normalized and URLs are
  credential-stripped.

Default-off, so existing dep-graph output is unchanged.

### Notes for the reviewer

- Behaviour is entirely gated on the new flag; all pre-existing fixture/graph
  tests are untouched and still pass (`npm test` — 68 total), plus new unit
  coverage for the selection ladder, hash formatting, per-source-type URL
  construction, the fragment matching the selected file, the v1/v2 layouts, and
  the builder emitting labels only when the flag is set.
- The single node-emit site (`poetry-dep-graph-builder.ts`) and single
  lockfile-read site (`lock-file-parser.ts`) are the only behavioural changes;
  `component-metadata-labels.ts` is new and self-contained.
- **The one assumption worth reviewing:** a package with no `[package.source]`
  stanza is treated as having come from `pypi.org`. Verified empirically against
  poetry 2.4.1 — a custom **primary** source (even one pointed at
  `https://pypi.org/simple`) is recorded as `type = "legacy"` with its own root,
  so only the implicit built-in PyPI is ever bare. A private-index package
  therefore can't be mislabelled as PyPI.
- Downstream: `snyk-python-plugin` will thread the flag through to this 4th
  param (separate PR); the CLI already forwards `--include-component-metadata`
  to the plugin, so no CLI source change is needed.
- Verified end-to-end against a poetry fixture: `jinja2` resolves to its
  universal-wheel hash + `https://pypi.org/simple/jinja2/#Jinja2-2.11.3-py2.py3-none-any.whl`,
  and `markupsafe` (no universal wheel) to its sdist hash +
  `https://pypi.org/simple/markupsafe/#MarkupSafe-1.1.1.tar.gz` — each fragment
  pointing at the file whose hash is reported.
- The full design rationale (why one artifact per node, prior art vs
  `cyclonedx-py`, CycloneDX/SPDX mapping, the resolve-path alternative) is
  written up separately and not included here.

### More information

- [CMPA-656](https://snyksec.atlassian.net/browse/CMPA-656)

### Screenshots

N/A


[CMPA-656]: https://snyksec.atlassian.net/browse/CMPA-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ