### PR TITLE
fix: strip query strings from distribution:url source URLs

### DIFF
--- a/lib/component-metadata-labels.ts
+++ b/lib/component-metadata-labels.ts
@@ -189,12 +189,20 @@ function normalizePep503Name(name: string): string {
   return name.toLowerCase().replace(/[-_.]+/g, '-');
 }
 
-// Strip embedded basic-auth credentials and any URL fragment before emitting.
+// Reduce a source URL to its canonical identity before it becomes a
+// distribution:url provenance label: clear basic-auth userinfo, the query
+// string, and the fragment. distribution:url is not a fetch target — a PEP 503
+// project page is `<root>/<pkg>/#<file>` and needs no query, and a direct-url
+// artifact's query is not part of its identity — so the query never belongs in
+// the label. Query strings can also carry authentication material, so dropping
+// them keeps that out of the label. The fragment is re-added by the caller from
+// the selected artifact, so a source-provided one is noise.
 function sanitizeUrl(rawUrl: string): string | undefined {
   try {
     const url = new URL(rawUrl);
     url.username = '';
     url.password = '';
+    url.search = '';
     url.hash = '';
     return url.toString();
   } catch {

--- a/test/unit/lib/component-metadata-labels.test.ts
+++ b/test/unit/lib/component-metadata-labels.test.ts
@@ -175,6 +175,60 @@ describe('getComponentMetadataLabels', () => {
       );
     });
 
+    it('strips a query-string token from a legacy index URL', () => {
+      // Some private indexes carry authentication material in the query string
+      // rather than as basic-auth userinfo. It is not part of the artifact's
+      // identity, so it must not appear in the label — and it must not corrupt
+      // the appended project path.
+      const labels = getComponentMetadataLabels({
+        name: 'foo',
+        files: [{ file: 'foo-1.0.0.tar.gz', hash: 'sha256:a' }],
+        source: {
+          type: 'legacy',
+          url: 'https://index.example/simple?token=s3cr3t',
+        },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://index.example/simple/foo/#foo-1.0.0.tar.gz',
+      );
+    });
+
+    it('strips a signed-URL query from a direct `url` source', () => {
+      // A direct-URL dependency can point at a signed artifact URL whose query
+      // string is authentication material rather than identity. distribution:url
+      // is provenance, not a fetch target, so the query is dropped.
+      const labels = getComponentMetadataLabels({
+        name: 'example-pkg',
+        files: [
+          { file: 'example_pkg-1.0.0-py3-none-any.whl', hash: 'sha256:a' },
+        ],
+        source: {
+          type: 'url',
+          url:
+            'https://bucket.s3.example/example_pkg-1.0.0-py3-none-any.whl' +
+            '?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIA',
+        },
+      });
+      expect(labels['distribution:url']).toBe(
+        'https://bucket.s3.example/example_pkg-1.0.0-py3-none-any.whl',
+      );
+    });
+
+    it('strips userinfo and query together', () => {
+      const labels = getComponentMetadataLabels({
+        name: 'foo',
+        files: [{ file: 'foo-1.0.0.tar.gz', hash: 'sha256:a' }],
+        source: {
+          type: 'legacy',
+          url: 'https://user:pass@index.example/simple?token=s3cr3t',
+        },
+      });
+      const url = labels['distribution:url'];
+      expect(url).toBe('https://index.example/simple/foo/#foo-1.0.0.tar.gz');
+      expect(url).not.toContain('s3cr3t');
+      expect(url).not.toContain('user:pass');
+    });
+
     it('emits no URL for a git source', () => {
       const labels = getComponentMetadataLabels({
         name: 'forked-tool',


### PR DESCRIPTION
## What does this PR do?

A source URL from a package's `[package.source]` can include a query string that
isn't part of the artifact's identity. `distribution:url` is a **provenance
label, not a fetch target** — a PEP 503 project page is `<root>/<pkg>/#<file>`
and needs no query, and a direct-url artifact's query isn't part of its identity
— so the query string shouldn't appear in the emitted label.

`sanitizeUrl` already stripped basic-auth userinfo and the fragment; this extends
it to clear the query string as well. Query strings can also carry authentication
material, so dropping them keeps that out of the label as a matter of hygiene.

It also corrects a malformed label for `legacy` index roots that carried a query
string: previously the query landed in the *middle* of the appended project path
(`…/simple?token=x/pkg/#file`), so the emitted URL wasn't a valid project page.

## Where should the reviewer start?

`lib/component-metadata-labels.ts` — the one-line change in `sanitizeUrl`
(`url.search = ''`) plus the updated comment. Then the three added cases in
`test/unit/lib/component-metadata-labels.test.ts`.

## Tests

Added coverage for a query-string on a legacy index, a signed-URL query on a
direct `url` source, and combined userinfo+query. Each fails against the previous
behaviour and passes now. Full suite: **72 passing**, lint clean, `tsc` build
clean.

## Risk

**Low.** Sanitisation tightening on a label that already stripped userinfo; no
change to hash selection, dep-graph shape, or any URL without a query string. The
only observable difference is that a query string on a source URL is no longer
emitted.

## Downstream

Consumed by `snyk-python-plugin` → Snyk CLI. After release, bump the parser in
`snyk-python-plugin`, then bump the plugin in the CLI (snyk/cli#7048) and extend
the CLI's poetry provenance test to the query-string case.
